### PR TITLE
Allow more arguments in the custom tag methods

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,7 +8,7 @@ ignore = E203,E501,E731,W503,W605
 import-order-style = google
 # Packages added in this list should be added to the setup.cfg file as well
 application-import-names =
-    pypants
+    fluxio_parser
 exclude =
     *vendor*
     .venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
         # Need to define stages explicitly since `default_stages` was not being respected
         stages: [commit]
+      - id: end-of-file-fixer
 
   - repo: local
     hooks:

--- a/fluxio_parser/__init__.py
+++ b/fluxio_parser/__init__.py
@@ -1,5 +1,5 @@
 """Main exports"""
 
-from .parser import parse_project_tree  # noqa: F401
+from fluxio_parser.parser import parse_project_tree  # noqa: F401
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/fluxio_parser/parser.py
+++ b/fluxio_parser/parser.py
@@ -2,8 +2,8 @@
 
 import ast
 
-from .transformers import ScriptTransformer
-from .visitors import ScriptVisitor
+from fluxio_parser.transformers import ScriptTransformer
+from fluxio_parser.visitors import ScriptVisitor
 
 
 def parse_project_tree(

--- a/fluxio_parser/resource_decorators.py
+++ b/fluxio_parser/resource_decorators.py
@@ -2,8 +2,8 @@
 import ast
 from typing import Any, Optional
 
-from .exceptions import assert_supported_operation
-from .util import CallableOption, GET_VALUE_MAP
+from fluxio_parser.exceptions import assert_supported_operation
+from fluxio_parser.util import CallableOption, GET_VALUE_MAP
 
 
 def get_subscribe_status(node: Any, visitor: Optional[ast.NodeVisitor]) -> str:

--- a/fluxio_parser/states/__init__.py
+++ b/fluxio_parser/states/__init__.py
@@ -1,9 +1,11 @@
-from .base import State
-from .choice import ChoiceState
-from .fail import FailState
-from .map_ import MapState
-from .parallel import ParallelState
-from .pass_ import PassState
-from .succeed import SucceedState
-from .tasks import create_task_state, TaskState
-from .wait import WaitState
+"""Contains exports for the states subpackage"""
+from fluxio_parser.states.base import State
+from fluxio_parser.states.choice import ChoiceState
+from fluxio_parser.states.fail import FailState
+from fluxio_parser.states.map_ import MapState
+from fluxio_parser.states.parallel import ParallelState
+from fluxio_parser.states.pass_ import PassState
+from fluxio_parser.states.succeed import SucceedState
+from fluxio_parser.states.tasks import create_task_state
+from fluxio_parser.states.tasks.base import TaskState
+from fluxio_parser.states.wait import WaitState

--- a/fluxio_parser/states/base.py
+++ b/fluxio_parser/states/base.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 import astor
 import networkx as nx
 
-from ..util import hash_node
+from fluxio_parser.util import hash_node
 
 
 class StateMachineFragment:
@@ -24,10 +24,12 @@ class StateMachineFragment:
         self._source = astor.to_source(ast_node).strip()
         self._hash = hash_node(ast_node)
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """Returns string representation of the object"""
         return str(self.key)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """Returns REPR representation of the object"""
         return f"{self.__class__.__name__}(key={self.key})"
 
     def _set_end_or_next(self, data: Dict) -> Dict:
@@ -40,6 +42,7 @@ class StateMachineFragment:
 
         Returns:
             modified input data
+
         """
         edges = self.edges
         if len(edges) == 0:

--- a/fluxio_parser/states/choice.py
+++ b/fluxio_parser/states/choice.py
@@ -222,7 +222,7 @@ class ChoiceState(State):
         }
     """
 
-    def __init__(self, state_graph: nx.DiGraph, key: str, ast_node: Any) -> None:
+    def __init__(self, state_graph: "nx.DiGraph", key: str, ast_node: Any) -> None:
         """Initializer
 
         Args:

--- a/fluxio_parser/states/choice.py
+++ b/fluxio_parser/states/choice.py
@@ -1,10 +1,13 @@
 """Contains the classes that represent the AWS Step Functions Choice State"""
 import ast
-from typing import Any, Dict
+from typing import Any, Dict, TYPE_CHECKING
 
-from ..exceptions import assert_supported_operation, UnsupportedOperation
-from ..util import convert_input_data_ref, hash_node
-from .base import State, StateMachineFragment
+from fluxio_parser.exceptions import assert_supported_operation, UnsupportedOperation
+from fluxio_parser.states.base import State, StateMachineFragment
+from fluxio_parser.util import convert_input_data_ref, hash_node
+
+if TYPE_CHECKING:
+    import networkx as nx
 
 # Map of either:
 # * tuple of:
@@ -219,13 +222,15 @@ class ChoiceState(State):
         }
     """
 
-    def __init__(self, state_graph: "nx.DiGraph", key: str, ast_node: Any) -> None:
-        """
+    def __init__(self, state_graph: nx.DiGraph, key: str, ast_node: Any) -> None:
+        """Initializer
+
         Args:
             state_graph: DAG of state machine fragments with edges between them
             key: Key of the fragment in the state machine's States value. This only
                 really applies to States, not generic fragments.
             ast_node: AST node for this fragment in the .sfn file
+
         """
         super().__init__(state_graph, key, ast_node)
         self.choice_branches = []
@@ -242,6 +247,7 @@ class ChoiceState(State):
 
         Returns:
             new ChoiceBranch instance
+
         """
         choice_branch = ChoiceBranch(
             self.state_graph, f"ChoiceBranch-{hash_node(node)}", node

--- a/fluxio_parser/states/fail.py
+++ b/fluxio_parser/states/fail.py
@@ -1,7 +1,7 @@
 """Contains the class that represents the AWS Step Functions Fail State"""
 from typing import Dict
 
-from .base import State
+from fluxio_parser.states.base import State
 
 
 class FailState(State):

--- a/fluxio_parser/states/map_.py
+++ b/fluxio_parser/states/map_.py
@@ -1,9 +1,17 @@
 """Contains the classes that represent the AWS Step Functions Map State"""
 import ast
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, TYPE_CHECKING
 
-from ..util import CallableOption, convert_input_data_ref, GET_VALUE_MAP, parse_options
-from .base import State
+from fluxio_parser.states.base import State
+from fluxio_parser.util import (
+    CallableOption,
+    convert_input_data_ref,
+    GET_VALUE_MAP,
+    parse_options,
+)
+
+if TYPE_CHECKING:
+    import networkx as nx
 
 # Map of task option name to an option schema
 OPTION_MAP = {
@@ -48,18 +56,20 @@ class MapState(State):
 
     def __init__(
         self,
-        state_graph: "nx.DiGraph",
+        state_graph: nx.DiGraph,
         key: str,
         ast_node: Any,
-        iterator: "StateMachineVisitor",
+        iterator: "StateMachineVisitor",  # noqa: F821
     ) -> None:
-        """
+        """Initializer
+
         Args:
             state_graph: DAG of state machine fragments with edges between them
             key: Key of the fragment in the state machine's States value. This only
                 really applies to States, not generic fragments.
             ast_node: AST node for this fragment in the .sfn file
             iterator: State machine visitor for the iterator function
+
         """
         super().__init__(state_graph, key, ast_node)
         self.iterator = iterator
@@ -77,6 +87,7 @@ class MapState(State):
 
         Returns:
             input path string
+
         """
         if len(self.ast_node.value.args) > 0:
             return convert_input_data_ref(self.ast_node.value.args[0])
@@ -91,6 +102,7 @@ class MapState(State):
 
         Returns:
             result path string or None
+
         """
         if isinstance(self.ast_node, ast.Assign) and len(self.ast_node.targets) > 0:
             return convert_input_data_ref(self.ast_node.targets[0])

--- a/fluxio_parser/states/map_.py
+++ b/fluxio_parser/states/map_.py
@@ -56,7 +56,7 @@ class MapState(State):
 
     def __init__(
         self,
-        state_graph: nx.DiGraph,
+        state_graph: "nx.DiGraph",
         key: str,
         ast_node: Any,
         iterator: "StateMachineVisitor",  # noqa: F821

--- a/fluxio_parser/states/parallel.py
+++ b/fluxio_parser/states/parallel.py
@@ -3,10 +3,10 @@ from typing import Any, Dict, List, TYPE_CHECKING
 
 import networkx as nx
 
-from .base import State
+from fluxio_parser.states.base import State
 
 if TYPE_CHECKING:
-    from ..visitors import StateMachineVisitor
+    from fluxio_parser.visitors import StateMachineVisitor
 
 
 class ParallelState(State):

--- a/fluxio_parser/states/pass_.py
+++ b/fluxio_parser/states/pass_.py
@@ -6,10 +6,13 @@ from typing import Any, Dict
 
 import astor
 
-from ..constants import INVALID_RESULT_PATH_PATTERN, RESERVED_INPUT_DATA_KEYS
-from ..exceptions import assert_supported_operation, UnsupportedOperation
-from ..util import convert_input_data_ref
-from .base import State
+from fluxio_parser.constants import (
+    INVALID_RESULT_PATH_PATTERN,
+    RESERVED_INPUT_DATA_KEYS,
+)
+from fluxio_parser.exceptions import assert_supported_operation, UnsupportedOperation
+from fluxio_parser.states.base import State
+from fluxio_parser.util import convert_input_data_ref
 
 
 class PassState(State):
@@ -67,6 +70,7 @@ class PassState(State):
 
         Returns:
             result value
+
         """
         if isinstance(self.ast_node, ast.Assign):
             source = astor.to_source(self.ast_node.value).strip()
@@ -94,6 +98,7 @@ class PassState(State):
 
         Returns:
             result path string
+
         """
         if isinstance(self.ast_node, ast.Assign):
             result_path = convert_input_data_ref(self.ast_node.targets[0])

--- a/fluxio_parser/states/succeed.py
+++ b/fluxio_parser/states/succeed.py
@@ -1,7 +1,7 @@
 """Contains the class that represents the AWS Step Functions Succeed State"""
 from typing import Dict
 
-from .base import State
+from fluxio_parser.states.base import State
 
 
 class SucceedState(State):
@@ -12,15 +12,12 @@ class SucceedState(State):
 
     See: https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-succeed-state.html
 
-    For example::
-
-        return
-
-    resolves to::
+    For example, ``return`` resolves to::
 
         {
             "Type": "Succeed"
         }
+
     """
 
     TERMINAL = True

--- a/fluxio_parser/states/tasks/__init__.py
+++ b/fluxio_parser/states/tasks/__init__.py
@@ -1,14 +1,14 @@
 """Contains a factory function for creating new Task state instances"""
 from typing import Any, Union
 
-from ...util import parse_options
-from .base import OPTION_MAP, TaskState
-from .codebuild import CodeBuildTaskState
-from .ecs import ECSTaskState
-from .ecs_worker import ECSWorkerTaskState
-from .lambda_function import LambdaTaskState
-from .lambda_pexpm_runner import LambdaPEXPMRunnerTaskState
-from .state_machine import StateMachineTaskState
+from fluxio_parser.states.tasks.base import OPTION_MAP
+from fluxio_parser.states.tasks.codebuild import CodeBuildTaskState
+from fluxio_parser.states.tasks.ecs import ECSTaskState
+from fluxio_parser.states.tasks.ecs_worker import ECSWorkerTaskState
+from fluxio_parser.states.tasks.lambda_function import LambdaTaskState
+from fluxio_parser.states.tasks.lambda_pexpm_runner import LambdaPEXPMRunnerTaskState
+from fluxio_parser.states.tasks.state_machine import StateMachineTaskState
+from fluxio_parser.util import parse_options
 
 #: Map of service key to task state class
 TASK_STATE_MAP = {
@@ -37,6 +37,7 @@ def create_task_state(
 
     Returns:
         new task state
+
     """
     service = visitor.attributes.get("service", "lambda")
     options = {}

--- a/fluxio_parser/states/tasks/base.py
+++ b/fluxio_parser/states/tasks/base.py
@@ -6,10 +6,15 @@ from typing import Any, Dict, Optional, Set
 
 import astor
 
-from ...constants import INVALID_RESULT_PATH_PATTERN, RESERVED_INPUT_DATA_KEYS
-from ...exceptions import assert_supported_operation
-from ...transformers import DataDictTransformer
-from ...util import (
+from fluxio_parser.constants import (
+    INVALID_RESULT_PATH_PATTERN,
+    RESERVED_INPUT_DATA_KEYS,
+)
+from fluxio_parser.exceptions import assert_supported_operation
+from fluxio_parser.states.base import State, StateMachineFragment
+from fluxio_parser.states.tasks.retry import Retry, RETRY_OPTION_MAP
+from fluxio_parser.transformers import DataDictTransformer
+from fluxio_parser.util import (
     CallableOption,
     convert_input_data_ref,
     GET_VALUE_MAP,
@@ -17,8 +22,6 @@ from ...util import (
     parse_options,
     serialize_error_name,
 )
-from ..base import State, StateMachineFragment
-from .retry import Retry, RETRY_OPTION_MAP
 
 
 def convert_data_dict(node: Any, visitor: ast.NodeVisitor) -> str:

--- a/fluxio_parser/states/tasks/codebuild.py
+++ b/fluxio_parser/states/tasks/codebuild.py
@@ -2,7 +2,7 @@
 import json
 from typing import Dict, Set
 
-from .base import TaskState
+from fluxio_parser.states.tasks.base import TaskState
 
 
 class CodeBuildTaskState(TaskState):

--- a/fluxio_parser/states/tasks/ecs.py
+++ b/fluxio_parser/states/tasks/ecs.py
@@ -1,7 +1,7 @@
 """Contains class for a Task State that runs an ECS task"""
 from typing import Dict, Set
 
-from .base import TaskState
+from fluxio_parser.states.tasks.base import TaskState
 
 
 class ECSTaskState(TaskState):

--- a/fluxio_parser/states/tasks/ecs_worker.py
+++ b/fluxio_parser/states/tasks/ecs_worker.py
@@ -1,7 +1,7 @@
 """Contains class for a Task State that feeds an ECS worker"""
 from typing import Dict, Set
 
-from .base import TaskState
+from fluxio_parser.states.tasks.base import TaskState
 
 
 class ECSWorkerTaskState(TaskState):

--- a/fluxio_parser/states/tasks/lambda_function.py
+++ b/fluxio_parser/states/tasks/lambda_function.py
@@ -1,8 +1,8 @@
 """Contains class used to represent a Task State that integrates with Lambda"""
 from typing import Dict, Set
 
-from .base import TaskState
-from .retry import Retry
+from fluxio_parser.states.tasks.base import TaskState
+from fluxio_parser.states.tasks.retry import Retry
 
 
 class LambdaTaskState(TaskState):

--- a/fluxio_parser/states/tasks/lambda_pexpm_runner.py
+++ b/fluxio_parser/states/tasks/lambda_pexpm_runner.py
@@ -1,8 +1,8 @@
 """Contains a class representing a Task State for Lambda via the PEXPM Runner"""
 from typing import Dict, Set
 
-from .base import TaskState
-from .retry import Retry
+from fluxio_parser.states.tasks.base import TaskState
+from fluxio_parser.states.tasks.retry import Retry
 
 
 class LambdaPEXPMRunnerTaskState(TaskState):

--- a/fluxio_parser/states/tasks/retry.py
+++ b/fluxio_parser/states/tasks/retry.py
@@ -2,7 +2,11 @@
 import ast
 from typing import Dict, List
 
-from ...util import CallableOption, GET_VALUE_MAP, serialize_error_name  # noqa
+from fluxio_parser.util import (  # noqa
+    CallableOption,
+    GET_VALUE_MAP,
+    serialize_error_name,
+)
 
 RETRY_OPTION_MAP = {
     "on_exceptions": CallableOption(

--- a/fluxio_parser/states/tasks/retry.py
+++ b/fluxio_parser/states/tasks/retry.py
@@ -2,11 +2,7 @@
 import ast
 from typing import Dict, List
 
-from fluxio_parser.util import (  # noqa
-    CallableOption,
-    GET_VALUE_MAP,
-    serialize_error_name,
-)
+from fluxio_parser.util import CallableOption, GET_VALUE_MAP, serialize_error_name
 
 RETRY_OPTION_MAP = {
     "on_exceptions": CallableOption(

--- a/fluxio_parser/states/tasks/state_machine.py
+++ b/fluxio_parser/states/tasks/state_machine.py
@@ -1,7 +1,7 @@
 """Contains class used to represent a Task State that integrates with Step Functions"""
 from typing import Dict, Set
 
-from .base import TaskState
+from fluxio_parser.states.tasks.base import TaskState
 
 
 class StateMachineTaskState(TaskState):

--- a/fluxio_parser/states/wait.py
+++ b/fluxio_parser/states/wait.py
@@ -2,9 +2,9 @@
 import ast
 from typing import Dict
 
-from ..exceptions import UnsupportedOperation
-from ..util import convert_input_data_ref
-from .base import State
+from fluxio_parser.exceptions import UnsupportedOperation
+from fluxio_parser.states.base import State
+from fluxio_parser.util import convert_input_data_ref
 
 
 class WaitState(State):

--- a/fluxio_parser/transformers/__init__.py
+++ b/fluxio_parser/transformers/__init__.py
@@ -1,3 +1,4 @@
-from .data_dict import DataDictTransformer
-from .run_method import RunMethodTransformer
-from .script import ScriptTransformer
+"""Contains exports from the transformers subpackage"""
+from fluxio_parser.transformers.data_dict import DataDictTransformer
+from fluxio_parser.transformers.run_method import RunMethodTransformer
+from fluxio_parser.transformers.script import ScriptTransformer

--- a/fluxio_parser/transformers/data_dict.py
+++ b/fluxio_parser/transformers/data_dict.py
@@ -2,7 +2,7 @@
 import ast
 from typing import Any
 
-from ..util import convert_input_data_ref
+from fluxio_parser.util import convert_input_data_ref
 
 
 class DataDictTransformer(ast.NodeTransformer):

--- a/fluxio_parser/util.py
+++ b/fluxio_parser/util.py
@@ -7,7 +7,7 @@ from typing import Any, Callable, Dict, NamedTuple, Optional
 
 import astor
 
-from .exceptions import assert_supported_operation, UnsupportedOperation
+from fluxio_parser.exceptions import assert_supported_operation, UnsupportedOperation
 
 logger = logging.getLogger(__name__)
 

--- a/fluxio_parser/util.py
+++ b/fluxio_parser/util.py
@@ -107,9 +107,9 @@ class CallableOption(NamedTuple):
     #: Getter function for extracting the value from the AST node
     get_value: Callable[[Any, ast.NodeVisitor], Any]
     #: Default value if the option is not provided
-    default_value: Any = None  # noqa
+    default_value: Any = None
     #: Flag indicating that this option is required
-    required: bool = False  # noqa
+    required: bool = False
 
 
 class OptionsMap(dict):

--- a/fluxio_parser/visitors/__init__.py
+++ b/fluxio_parser/visitors/__init__.py
@@ -1,4 +1,5 @@
-from .event_processor import EventProcessorVisitor
-from .script import ScriptVisitor
-from .state_machine import StateMachineVisitor
-from .task import TaskVisitor
+"""Contains exports for the visitors subpackage"""
+from fluxio_parser.visitors.event_processor import EventProcessorVisitor
+from fluxio_parser.visitors.script import ScriptVisitor
+from fluxio_parser.visitors.state_machine import StateMachineVisitor
+from fluxio_parser.visitors.task import TaskVisitor

--- a/fluxio_parser/visitors/event_processor.py
+++ b/fluxio_parser/visitors/event_processor.py
@@ -3,7 +3,7 @@
 import ast
 from typing import Any
 
-from ..exceptions import assert_supported_operation, UnsupportedOperation
+from fluxio_parser.exceptions import assert_supported_operation, UnsupportedOperation
 
 
 class EventProcessorVisitor(ast.NodeVisitor):
@@ -43,9 +43,10 @@ class EventProcessorVisitor(ast.NodeVisitor):
         )
         arg_name_set = {arg.arg for arg in node.args.args}
         assert_supported_operation(
-            arg_name_set == {"message"},
-            f"get_custom_tags_* methods must only accept a positional argument of  message."
-            f" Provided: {', '.join(arg_name_set)}",
+            arg_name_set == {"message", "input_data", "state_data_client"},
+            "get_custom_tags_* methods must only accept positional arguments of"
+            " (message, input_data, state_data_client)."
+            f" Provided: {', '.join([arg.arg for arg in node.args.args])}",
             node,
         )
 

--- a/fluxio_parser/visitors/script.py
+++ b/fluxio_parser/visitors/script.py
@@ -3,15 +3,12 @@ import ast
 from collections import defaultdict
 from typing import Any, Dict, Set
 
-from fluxio_parser.exceptions import (  # noqa
-    assert_supported_operation,
-    UnsupportedOperation,
-)
-from fluxio_parser.resource_decorators import RESOURCE_DECORATOR_MAP  # noqa
-from fluxio_parser.util import parse_options  # noqa
-from fluxio_parser.visitors.event_processor import EventProcessorVisitor  # noqa
-from fluxio_parser.visitors.state_machine import StateMachineVisitor  # noqa
-from fluxio_parser.visitors.task import TaskVisitor  # noqa
+from fluxio_parser.exceptions import assert_supported_operation, UnsupportedOperation
+from fluxio_parser.resource_decorators import RESOURCE_DECORATOR_MAP
+from fluxio_parser.util import parse_options
+from fluxio_parser.visitors.event_processor import EventProcessorVisitor
+from fluxio_parser.visitors.state_machine import StateMachineVisitor
+from fluxio_parser.visitors.task import TaskVisitor
 
 
 class ScriptVisitor(ast.NodeVisitor):

--- a/fluxio_parser/visitors/script.py
+++ b/fluxio_parser/visitors/script.py
@@ -3,12 +3,15 @@ import ast
 from collections import defaultdict
 from typing import Any, Dict, Set
 
-from ..exceptions import assert_supported_operation, UnsupportedOperation  # noqa
-from ..resource_decorators import RESOURCE_DECORATOR_MAP  # noqa
-from ..util import parse_options  # noqa
-from .event_processor import EventProcessorVisitor  # noqa
-from .state_machine import StateMachineVisitor  # noqa
-from .task import TaskVisitor  # noqa
+from fluxio_parser.exceptions import (  # noqa
+    assert_supported_operation,
+    UnsupportedOperation,
+)
+from fluxio_parser.resource_decorators import RESOURCE_DECORATOR_MAP  # noqa
+from fluxio_parser.util import parse_options  # noqa
+from fluxio_parser.visitors.event_processor import EventProcessorVisitor  # noqa
+from fluxio_parser.visitors.state_machine import StateMachineVisitor  # noqa
+from fluxio_parser.visitors.task import TaskVisitor  # noqa
 
 
 class ScriptVisitor(ast.NodeVisitor):

--- a/fluxio_parser/visitors/state_machine.py
+++ b/fluxio_parser/visitors/state_machine.py
@@ -7,8 +7,8 @@ from typing import Any, Dict, List, Optional
 import astor
 import networkx as nx
 
-from ..exceptions import assert_supported_operation, UnsupportedOperation
-from ..states import (
+from fluxio_parser.exceptions import assert_supported_operation, UnsupportedOperation
+from fluxio_parser.states import (
     ChoiceState,
     create_task_state,
     FailState,
@@ -20,7 +20,7 @@ from ..states import (
     TaskState,
     WaitState,
 )
-from ..util import hash_node
+from fluxio_parser.util import hash_node
 
 
 class StateMachineVisitor(ast.NodeVisitor):

--- a/fluxio_parser/visitors/task.py
+++ b/fluxio_parser/visitors/task.py
@@ -2,9 +2,9 @@
 import ast
 from typing import Any, Callable, NamedTuple, Optional, Set, Union
 
-from ..exceptions import assert_supported_operation, UnsupportedOperation
-from ..transformers import RunMethodTransformer
-from ..util import GET_VALUE_MAP
+from fluxio_parser.exceptions import assert_supported_operation, UnsupportedOperation
+from fluxio_parser.transformers import RunMethodTransformer
+from fluxio_parser.util import GET_VALUE_MAP
 
 
 class Attribute(NamedTuple):

--- a/fluxio_parser/visitors/task.py
+++ b/fluxio_parser/visitors/task.py
@@ -11,11 +11,11 @@ class Attribute(NamedTuple):
     """Data class for a task class attribute schema"""
 
     #: Getter function for extracting the value from the AST node
-    get_value: Callable  # noqa
+    get_value: Callable
     #: Default value if the attribute is not provided
-    default_value: Any  # noqa
+    default_value: Any
     #: Set of allowed values
-    allowed_values: Set[Union[str, int]] = None  # noqa
+    allowed_values: Set[Union[str, int]] = None
 
 
 # Map of task class attribute name to an attribute schema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fluxio-parser"
-version = "0.3.0"
+version = "0.3.1"
 description = "Fluxio parser library"
 authors = ["Jonathan Drake <jdrake@narrativescience.com>"]
 license = "BSD-3-Clause"

--- a/tests/test_event_processor_visitor.py
+++ b/tests/test_event_processor_visitor.py
@@ -23,10 +23,10 @@ class MyEventProcessor(EventProcessor):
         """Should not fail when proper methods set"""
         code = """
 class MyEventProcessor(EventProcessor):
-    async def get_custom_tags_Foo(message):
+    async def get_custom_tags_Foo(message, input_data, state_data_client):
         pass
 
-    async def get_custom_tags_Bar(message):
+    async def get_custom_tags_Bar(message, input_data, state_data_client):
         pass
 """
         tree = ast.parse(code)


### PR DESCRIPTION
I need to inject more arguments into the get_custom_tags_* methods. 

This PR also replaces relative imports with absolute ones and adds the newline EOF pre commit hook.